### PR TITLE
Improve image rendering

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -30,7 +30,7 @@ def get_cropped_image(x, y, grey=False, retries=0):
     im = ImageOps.fit(im, (x, y))
     if grey:
         im = ImageOps.grayscale(im)
-    im.save(out, "WEBP", quality=50)
+    im.save(out, "WEBP", quality=80)
     out.seek(0)
     return out
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -23,8 +23,9 @@ def get_cropped_image(x, y, grey=False):
     im = Image.open(f"images/{im_src}")
     out = BytesIO()
     max_x, max_y = im.size
-    if x < max_x or y < max_y:
-        im = ImageOps.fit(im, (x, y))
+    if x < max_x and y < max_y:
+        return get_cropped_image(x, y, grey)
+    im = ImageOps.fit(im, (x, y))
     if grey:
         im = ImageOps.grayscale(im)
     im.save(out, "WEBP", quality=50)

--- a/wsgi.py
+++ b/wsgi.py
@@ -55,13 +55,13 @@ def bookmarklet():
 
 
 @app.route("/<int:x>/<int:y>")
-@cache.cached(10)
+@cache.cached(1)
 def generate(x, y):
     return make_response(x, y, COLOR)
 
 
 @app.route("/g/<int:x>/<int:y>")
-@cache.cached(10)
+@cache.cached(1)
 def generate_grey(x, y):
     return make_response(x, y, GREY)
 


### PR DESCRIPTION
This PR will do some fixes after user feedback.

- Decrease cache time for images to 1s.
- Increase image quality to 80.
- Always return an image with the correct dimensions, by trying another random image if the chosen image do not qualify. 
- To avoid a loop of failed retries, limit the retry image strategy to 10 retries.