### PR TITLE
Introduce image request query parameter for filtering and selection

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -21,8 +21,16 @@ def get_cropped_image(x, y, grey=False, retries=0):
     """crops a random image from collection"""
     if retries > 10:
         return None
-    selection = list(map(int, request.args.getlist("image")))
     options = os.listdir("./images")
+    try:
+        selection = list(
+            filter(
+                lambda i: i in range(0, len(options)),
+                map(int, request.args.getlist("image")),
+            )
+        )
+    except ValueError:
+        return None
     match len(selection):
         case 0:
             im_src = random.choice(options)

--- a/wsgi.py
+++ b/wsgi.py
@@ -21,7 +21,15 @@ def get_cropped_image(x, y, grey=False, retries=0):
     """crops a random image from collection"""
     if retries > 10:
         return None
-    im_src = random.choice(os.listdir("./images"))
+    selection = list(map(int, request.args.getlist("image")))
+    options = os.listdir("./images")
+    match len(selection):
+        case 0:
+            im_src = random.choice(options)
+        case 1:
+            im_src = options[selection[0]]
+        case _:
+            im_src = options[random.choice(selection)]
     im = Image.open(f"images/{im_src}")
     out = BytesIO()
     max_x, max_y = im.size


### PR DESCRIPTION
This PR will add a less known feature from the Placekitten original: to choose an image based on image collection index. Like all indexes, first item in collection have index 0.

Usage is this, using the development URL:
http://127.0.0.1:5000/200/200?image=1

This will pick the second image of the collection.

I figured we could improve it by adding the feature to filter as well, using multiple params:

http://127.0.0.1:5000/200/200?image=1&image=3&image=9

This will randomize the second, fourth or tenth image.

Basic value sanitation is provided.

- Only numbers are allowed as values. A provided string as value triggers a HTTP 401 response.
- Only numbers within range (from 0 to image collection size) will be accepted - orther values are excluded.