### PR TITLE
View to list all images in collection

### DIFF
--- a/templates/list.html
+++ b/templates/list.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>placeany</title>
+  <style>
+    body {
+      width: 900px;
+      margin: 100px auto;
+    }
+
+    img {
+      display: block;
+    }
+
+    .grid {
+      display: flex;
+      gap: 1em;
+      flex-wrap: wrap;
+    }
+  </style>
+</head>
+
+<body>
+  <main>
+    <h1>placeany</h1>
+    <p>The following images are used on this placeany instance.
+      You may request a specific image by adding <b>?image=n</b> to your request
+      (where <b>n</b> is the number of the image you want), or filter the options
+      by adding multiple values like this: <b>?image=n1x&amp;image=n2&amp;image=n3</b>.</p>
+    <div class="grid">
+      {% for n in range(count) %}
+      <div class="unit">
+        <img src="/125/125?image={{ n }}" alt="">
+      </div>
+      {% endfor %}
+    </div>
+  </main>
+  <hr>
+  <footer role="contentinfo">
+    Also available as a <a href="/bookmarklet">Bookmarklet Service</a>.<br>
+    Source on <a href="https://github.com/madr/placeany">GitHub</a>.
+  </footer>
+</body>
+
+</html>

--- a/wsgi.py
+++ b/wsgi.py
@@ -10,6 +10,7 @@ app = Flask(__name__)
 
 GREY = "G"
 COLOR = "RGB"
+IMAGE_DIR = "./images"
 
 cache = Cache(config={"CACHE_TYPE": "SimpleCache"})
 
@@ -17,16 +18,17 @@ app = Flask(__name__)
 cache.init_app(app)
 
 
-def get_cropped_image(x, y, grey=False, retries=0):
+@cache.memoize(1)
+def get_cropped_image(x, y, s, grey=False, retries=0):
     """crops a random image from collection"""
     if retries > 10:
         return None
-    options = os.listdir("./images")
+    options = os.listdir(IMAGE_DIR)
     try:
         selection = list(
             filter(
                 lambda i: i in range(0, len(options)),
-                map(int, request.args.getlist("image")),
+                map(int, s),
             )
         )
     except ValueError:
@@ -38,7 +40,7 @@ def get_cropped_image(x, y, grey=False, retries=0):
             im_src = options[selection[0]]
         case _:
             im_src = options[random.choice(selection)]
-    im = Image.open(f"images/{im_src}")
+    im = Image.open(f"{IMAGE_DIR}/{im_src}")
     out = BytesIO()
     max_x, max_y = im.size
     if x > max_x and y > max_y:
@@ -51,8 +53,8 @@ def get_cropped_image(x, y, grey=False, retries=0):
     return out
 
 
-def make_response(x, y, color_mode=COLOR):
-    im = get_cropped_image(x, y, color_mode == GREY)
+def make_response(x, y, s, color_mode=COLOR):
+    im = get_cropped_image(x, y, s, color_mode == GREY)
     if not im:
         return Response(status=401)
     return send_file(im, mimetype="image/webp")
@@ -71,15 +73,13 @@ def bookmarklet():
 
 
 @app.route("/<int:x>/<int:y>")
-@cache.cached(1)
 def generate(x, y):
-    return make_response(x, y, COLOR)
+    return make_response(x, y, request.args.getlist("image"), COLOR)
 
 
 @app.route("/g/<int:x>/<int:y>")
-@cache.cached(1)
 def generate_grey(x, y):
-    return make_response(x, y, GREY)
+    return make_response(x, y, request.args.getlist("image"), GREY)
 
 
 if __name__ == "__main__":

--- a/wsgi.py
+++ b/wsgi.py
@@ -72,6 +72,12 @@ def bookmarklet():
     return render_template("bookmarklet.html", url=u)
 
 
+@app.route("/images")
+def collection():
+    c = len(os.listdir(IMAGE_DIR))
+    return render_template("list.html", count=c)
+
+
 @app.route("/<int:x>/<int:y>")
 def generate(x, y):
     return make_response(x, y, request.args.getlist("image"), COLOR)


### PR DESCRIPTION
This PR will add a view that list all images in alphabetical order.

It also mentions the `?image=n` feature.

In the creation of this page, it became apparent that the current cache method is an impediment, since it do not consider the image query parameter. By changing the cache to instead cache the image generation function rather than the views, the list page is possible.